### PR TITLE
Added locale as property

### DIFF
--- a/src/TimeInput.js
+++ b/src/TimeInput.js
@@ -44,13 +44,14 @@ var TimeInput = React.createClass({
       start: moment().startOf('day'),
       end: moment().endOf('day'),
       increment: {amount: 5, unit: 'minutes'},
-      inputValueFormat: 'LT'
+      inputValueFormat: 'LT',
+      locale: window.navigator.userLanguage || window.navigator.language
     };
   },
 
   getOptions: function() {
     var {amount, unit} = this.props.increment;
-    var time = moment(this.props.start);
+    var time = moment(this.props.start).locale(this.props.locale);
     var options = [];
 
     while (time.isBefore(this.props.end)) {


### PR DESCRIPTION
Hi,

I had an issue with using timeinput on a french website, as it was display time under the english format (AM and PM). I've added the possibility of passing locale as a property.
I've default to the browser locale value, but you might prefer to use english locale instead.

Thanks
