### PR TITLE
Introduce babel runtime polyfil

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -10,8 +10,15 @@ module.exports = {
 
   module: {
     loaders: [
-      {test: /\.js$/, loader: 'babel-loader?stage=0'},
-      {test: /\.css$/, loader: 'style-loader!css-loader'}
+      {
+        test: /\.js$/,
+        loader: 'babel-loader?stage=0&optional[]=runtime',
+        exclude: /node_modules/
+      },
+      {
+        test: /\.css$/,
+        loader: 'style-loader!css-loader'
+      }
     ]
   }
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "babel-core": "^4.7.16",
     "babel-loader": "^5.0.0",
+    "babel-runtime": "^5.8.20",
     "css-loader": "^0.9.1",
     "expect": "^1.6.0",
     "gulp": "^3.8.11",


### PR DESCRIPTION
To resolve the issue of not being able to find `Promise` on certain browsers, and other ES6 features, introduce babel-runtime polyfill as part of the webpack build process.

Fixes #5
